### PR TITLE
Properly hide the Akka methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,3 @@
 ## v1.0.0 - 2018-07-26
 
 Initial release of the separate monitoring library.
-
-## v0.0.1 - 2018-07-26
-
-Dummy changelog entry to help the tooling.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This renames the internal helper `withActorSystem` to
+`withMonitoringActorSystem` to avoid clashes with the helper in the main
+platform repo.

--- a/src/test/scala/uk/ac/wellcome/monitoring/MetricsSenderTest.scala
+++ b/src/test/scala/uk/ac/wellcome/monitoring/MetricsSenderTest.scala
@@ -40,7 +40,7 @@ class MetricsSenderTest
 
   describe("count") {
     it("counts a successful future") {
-      withActorSystem { actorSystem =>
+      withMonitoringActorSystem { actorSystem =>
         val amazonCloudWatch = mock[AmazonCloudWatch]
         withMetricsSender(actorSystem, amazonCloudWatch) { metricsSender =>
           val expectedResult = "foo"
@@ -61,7 +61,7 @@ class MetricsSenderTest
     }
 
     it("counts a failed future") {
-      withActorSystem { actorSystem =>
+      withMonitoringActorSystem { actorSystem =>
         val amazonCloudWatch = mock[AmazonCloudWatch]
         withMetricsSender(actorSystem, amazonCloudWatch) { metricsSender =>
           val f = Future {
@@ -80,7 +80,7 @@ class MetricsSenderTest
     }
 
     it("counts a recognised failure") {
-      withActorSystem { actorSystem =>
+      withMonitoringActorSystem { actorSystem =>
         val amazonCloudWatch = mock[AmazonCloudWatch]
         withMetricsSender(actorSystem, amazonCloudWatch) { metricsSender =>
           val f = Future {
@@ -102,7 +102,7 @@ class MetricsSenderTest
 
 
     it("groups 20 MetricDatum into one PutMetricDataRequest") {
-      withActorSystem { actorSystem =>
+      withMonitoringActorSystem { actorSystem =>
         val amazonCloudWatch = mock[AmazonCloudWatch]
         withMetricsSender(actorSystem, amazonCloudWatch) { metricsSender =>
           val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])
@@ -129,7 +129,7 @@ class MetricsSenderTest
     }
 
     it("takes at least one second to make 150 PutMetricData requests") {
-      withActorSystem { actorSystem =>
+      withMonitoringActorSystem { actorSystem =>
         val amazonCloudWatch = mock[AmazonCloudWatch]
         withMetricsSender(actorSystem, amazonCloudWatch) { metricsSender =>
           val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])

--- a/src/test/scala/uk/ac/wellcome/monitoring/fixtures/Akka.scala
+++ b/src/test/scala/uk/ac/wellcome/monitoring/fixtures/Akka.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import org.scalatest.concurrent.Eventually
 
 trait Akka extends Eventually {
-  private[monitoring] def withActorSystem[R] = fixture[ActorSystem, R](
+  private[monitoring] def withMonitoringActorSystem[R] = fixture[ActorSystem, R](
     create = ActorSystem(),
     destroy = eventually { _.terminate() }
   )

--- a/src/test/scala/uk/ac/wellcome/monitoring/fixtures/MetricsSenderFixture.scala
+++ b/src/test/scala/uk/ac/wellcome/monitoring/fixtures/MetricsSenderFixture.scala
@@ -38,7 +38,6 @@ trait MetricsSenderFixture
   def withMockMetricSender[R] =
     fixture[MetricsSender, R](
       create = {
-
         val metricsSender = mock[MetricsSender]
         when(
           metricsSender.count(


### PR DESCRIPTION
This library shouldn't be exposing this method, really. It’s not a monitoring-related fixture.