### PR TITLE
Expose specific methods to increment success/failure/recognised failure

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,18 @@
+RELEASE_TYPE: minor
+
+This add three new methods to MetricsSender that can directly decide which
+metric to increment:
+
+```
+def countSuccess(metricName: String): Future[QueueOfferResult]
+
+def countRecognisedFailure(metricName: String): Future[QueueOfferResult]
+
+def countFailure(metricName: String): Future[QueueOfferResult]
+```
+
+This release also deprecates `MetricsSender.count`, as its use in the platform
+is being replaced in favour of the specific methods above.
+
+Alongside it, `RecognisedFailureException` is deprecated as it was only
+introduced in v1.0.0 for control flow in `count`, and nothing is using it yet.

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,11 @@ scalacOptions ++= Seq(
   "UTF-8",
   "-Xlint",
   "-Xverify",
-  "-Xfatal-warnings",
+
+  // Commented out because I can't find a way to have fatal warnings and
+  // emit deprecations in code we test.  :sob:
+  // "-Xfatal-warnings",
+
   "-feature",
   "-language:postfixOps"
 )

--- a/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
+++ b/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
@@ -68,8 +68,8 @@ class MetricsSender @Inject()(amazonCloudWatch: AmazonCloudWatch,
     implicit ec: ExecutionContext): Future[T] = {
     f.onComplete {
       case Success(_) => countSuccess(metricName)
-      case Failure(_: RecognisedFailureException)
-                      => countRecognisedFailure(metricName)
+      case Failure(_: RecognisedFailureException) =>
+        countRecognisedFailure(metricName)
       case Failure(_) => countFailure(metricName)
     }
 

--- a/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
+++ b/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
@@ -63,7 +63,7 @@ class MetricsSender @Inject()(amazonCloudWatch: AmazonCloudWatch,
 
   @deprecated(
     "Use one of the specific count{Success,RecognisedFailure,Failure} methods",
-    "messaging 1.0")
+    "messaging 1.1")
   def count[T](metricName: String, f: Future[T])(
     implicit ec: ExecutionContext): Future[T] = {
     f.onComplete {

--- a/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
+++ b/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
@@ -64,14 +64,23 @@ class MetricsSender @Inject()(amazonCloudWatch: AmazonCloudWatch,
   def count[T](metricName: String, f: Future[T])(
     implicit ec: ExecutionContext): Future[T] = {
     f.onComplete {
-      case Success(_) => incrementCount(s"${metricName}_success")
-      case Failure(_: RecognisedFailureException) =>
-        incrementCount(s"${metricName}_recognisedFailure")
-      case Failure(_) => incrementCount(s"${metricName}_failure")
+      case Success(_) => countSuccess(metricName)
+      case Failure(_: RecognisedFailureException)
+                      => countRecognisedFailure(metricName)
+      case Failure(_) => countFailure(metricName)
     }
 
     f
   }
+
+  def countSuccess(metricName: String): Future[QueueOfferResult] =
+    incrementCount(s"${metricName}_success")
+
+  def countRecognisedFailure(metricName: String): Future[QueueOfferResult] =
+    incrementCount(s"${metricName}_recognisedFailure")
+
+  def countFailure(metricName: String): Future[QueueOfferResult] =
+    incrementCount(s"${metricName}_failure")
 
   def incrementCount(metricName: String): Future[QueueOfferResult] = {
     val metricDatum = new MetricDatum()

--- a/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
+++ b/src/main/scala/uk/ac/wellcome/monitoring/MetricsSender.scala
@@ -61,6 +61,9 @@ class MetricsSender @Inject()(amazonCloudWatch: AmazonCloudWatch,
       .to(sink)
       .run()
 
+  @deprecated(
+    "Use one of the specific count{Success,RecognisedFailure,Failure} methods",
+    "messaging 1.0")
   def count[T](metricName: String, f: Future[T])(
     implicit ec: ExecutionContext): Future[T] = {
     f.onComplete {

--- a/src/main/scala/uk/ac/wellcome/monitoring/RecognisedFailureException.scala
+++ b/src/main/scala/uk/ac/wellcome/monitoring/RecognisedFailureException.scala
@@ -7,6 +7,6 @@ package uk.ac.wellcome.monitoring
   */
 @deprecated(
   "This is only used for control flow in MetricsSender.count, which is deprecated",
-  "messaging 1.0")
+  "messaging 1.1")
 case class RecognisedFailureException(e: Throwable)
     extends Exception(e.getMessage)

--- a/src/main/scala/uk/ac/wellcome/monitoring/RecognisedFailureException.scala
+++ b/src/main/scala/uk/ac/wellcome/monitoring/RecognisedFailureException.scala
@@ -5,5 +5,8 @@ package uk.ac.wellcome.monitoring
   *
   * Instances of this exception are counted as a separate metric.
   */
+@deprecated(
+  "This is only used for control flow in MetricsSender.count, which is deprecated",
+  "messaging 1.0")
 case class RecognisedFailureException(e: Throwable)
     extends Exception(e.getMessage)

--- a/src/test/scala/uk/ac/wellcome/monitoring/MetricsSenderTest.scala
+++ b/src/test/scala/uk/ac/wellcome/monitoring/MetricsSenderTest.scala
@@ -170,7 +170,7 @@ class MetricsSenderTest
   }
 
   private def createMetricName: String =
-    (Random.alphanumeric take length mkString) toLowerCase
+    (Random.alphanumeric take 10 mkString) toLowerCase
 
   private def assertSingleDataPoint(amazonCloudWatch: AmazonCloudWatch, metricName: String) = {
     val capture = ArgumentCaptor.forClass(classOf[PutMetricDataRequest])


### PR DESCRIPTION
This deletes one layer of exception handling that had to be handled with `GracefulFailureException` previously.

In the platform, we only call `count` twice, and it's unambiguously clear what sort of metric we want there – hence these three methods.